### PR TITLE
Updates to item creation

### DIFF
--- a/src/cds_portal/components/input.py
+++ b/src/cds_portal/components/input.py
@@ -1,0 +1,120 @@
+from solara.alias import rv as v
+import solara
+from typing import Callable, Dict, List, Optional, TypeVar, Union
+
+from solara.components.input import _use_input_type, use_change
+
+
+T = TypeVar("T")
+
+@solara.component
+def NumericInput(
+    str_to_numeric: Callable[[Optional[str]], T],
+    label: str,
+    value: Union[None, T, solara.Reactive[Optional[T]], solara.Reactive[T]],
+    on_value: Union[None, Callable[[Optional[T]], None], Callable[[T], None]] = None,
+    on_error_change: Union[None, Callable[[Optional[bool]], None], Callable[[bool], None]] = None,
+    disabled: bool = False,
+    continuous_update: bool = False,
+    clearable: bool = False,
+    hide_details: Optional[Union[bool, str]] = None,
+    outlined: bool = False,
+    classes: List[str] = [],
+    style: Optional[Union[str, Dict[str, str]]] = None,
+):
+    """Integer input.
+
+    ## Arguments
+
+    * `label`: Label to display next to the slider.
+    * `value`: The currently entered value.
+    * `on_value`: Callback to call when the value changes.
+    * `disabled`: Whether the input is disabled.
+    * `continuous_update`: Whether to call the `on_value` callback on every change or only when the input loses focus or the enter key is pressed.
+    * `classes`: List of CSS classes to apply to the input.
+    * `style`: CSS style to apply to the input.
+    """
+
+
+    style_flat = solara.util._flatten_style(style)
+    classes_flat = solara.util._combine_classes(classes)
+
+    internal_value, error, set_value_cast = _use_input_type(
+        value,
+        str_to_numeric,
+        str,
+        on_value,
+    )
+
+    def on_v_model(value):
+        if continuous_update:
+            set_value_cast(value)
+
+    if on_error_change:
+        on_error_change(bool(error))
+
+    if error:
+        label += f" ({error})"
+    text_field = v.TextField(
+        v_model=internal_value,
+        on_v_model=on_v_model,
+        label=label,
+        disabled=disabled,
+        outlined=outlined,
+        # we are not using the number type, since we cannot validate invalid input
+        # see https://stackoverflow.blog/2022/12/26/why-the-number-input-is-the-worst-input/
+        # type="number",
+        hide_details=hide_details,
+        clearable=clearable,
+        error=bool(error),
+        class_=classes_flat,
+        style_=style_flat,
+    )
+    # use_change(text_field, set_value_cast, enabled=not continuous_update)
+    return text_field
+
+
+@solara.component
+def IntegerInput(
+    label: str,
+    value: Union[None, int, solara.Reactive[Optional[int]], solara.Reactive[int]],
+    on_value: Union[None, Callable[[Optional[int]], None], Callable[[int], None]] = None,
+    on_error_change: Union[None, Callable[[Optional[bool]], None], Callable[[bool], None]] = None,
+    disabled: bool = False,
+    continuous_update: bool = False,
+    clearable: bool = False,
+    hide_details: Optional[Union[bool, str]] = None,
+    optional: bool = False,
+    outlined: bool = False,
+    classes: List[str] = [],
+    style: Optional[Union[str, Dict[str, str]]] = None,
+):
+
+    def str_to_int(value: Optional[str]) -> Optional[int]:
+        if value:
+            try:
+                return int(value)
+            except ValueError:
+                if optional:
+                    return None
+                raise ValueError("Value must be an integer")
+        else:
+            if optional:
+                return None
+            else:
+                raise ValueError("Value cannot be empty")
+
+    return NumericInput(
+        str_to_int,
+        label=label,
+        value=value,
+        on_value=on_value,
+        on_error_change=on_error_change,
+        disabled=disabled,
+        continuous_update=continuous_update,
+        clearable=clearable,
+        hide_details=hide_details,
+        classes=classes,
+        outlined=outlined,
+        style=style,
+    )

--- a/src/cds_portal/pages/manage_classes/__init__.py
+++ b/src/cds_portal/pages/manage_classes/__init__.py
@@ -160,6 +160,7 @@ def Page():
                 "story": "Hubble's Law",
                 "code": cls["code"],
                 "id": cls["id"],
+                "expected_size": cls["expected_size"],
             }
 
             new_classes.append(new_class)
@@ -208,6 +209,7 @@ def Page():
                         {"text": "Story", "value": "story"},
                         {"text": "Code", "value": "code"},
                         {"text": "ID", "value": "id", "align": " d-none"},
+                        {"text": "Expected size", "value": "expected_size"},
                         # {"text": "Actions", "value": "actions", "align": "end"},
                     ],
                 )

--- a/src/cds_portal/pages/manage_classes/__init__.py
+++ b/src/cds_portal/pages/manage_classes/__init__.py
@@ -12,6 +12,7 @@ def CreateClassDialog(on_create_clicked: callable = None):
     text, set_text = solara.use_state("")
     stories, set_stories = solara.use_state([])
     expected_size, set_expected_size = solara.use_state(20)
+    asynchronous, set_asynchronous = solara.use_state(False)
 
     with rv.Dialog(
         v_model=active,
@@ -61,6 +62,12 @@ def CreateClassDialog(on_create_clicked: callable = None):
                     on_value=set_expected_size,
                 )
 
+                solara.Checkbox(
+                    label="Asynchronous class",
+                    value=asynchronous,
+                    on_value=set_asynchronous,
+                )
+
             rv.Divider()
 
             with rv.CardActions():
@@ -75,6 +82,7 @@ def CreateClassDialog(on_create_clicked: callable = None):
                             "name": f"{text}",
                             "stories": f"{', '.join(stories)}",
                             "expected_size": expected_size,
+                            "asynchronous": asynchronous,
                         }
                     )
                     set_active(False)
@@ -161,6 +169,7 @@ def Page():
                 "code": cls["code"],
                 "id": cls["id"],
                 "expected_size": cls["expected_size"],
+                "asynchronous": cls["asynchronous"],
             }
 
             new_classes.append(new_class)
@@ -170,7 +179,7 @@ def Page():
     solara.use_effect(_retrieve_classes, [])
 
     def _create_class_callback(class_info):
-        BASE_API.create_new_class(class_info["name"], class_info["expected_size"])
+        BASE_API.create_new_class(class_info)
         _retrieve_classes()
 
     def _delete_class_callback():
@@ -210,6 +219,7 @@ def Page():
                         {"text": "Code", "value": "code"},
                         {"text": "ID", "value": "id", "align": " d-none"},
                         {"text": "Expected size", "value": "expected_size"},
+                        {"text": "Asynchronous", "value": "asynchronous"},
                         # {"text": "Actions", "value": "actions", "align": "end"},
                     ],
                 )

--- a/src/cds_portal/pages/manage_classes/__init__.py
+++ b/src/cds_portal/pages/manage_classes/__init__.py
@@ -3,6 +3,8 @@ from datetime import datetime
 import solara
 from solara.alias import rv
 
+from cds_portal.components.input import IntegerInput
+
 from ...remote import BASE_API
 
 
@@ -13,6 +15,7 @@ def CreateClassDialog(on_create_clicked: callable = None):
     stories, set_stories = solara.use_state([])
     expected_size, set_expected_size = solara.use_state(20)
     asynchronous, set_asynchronous = solara.use_state(False)
+    expected_size_error = solara.use_reactive(False)
 
     with rv.Dialog(
         v_model=active,
@@ -56,10 +59,15 @@ def CreateClassDialog(on_create_clicked: callable = None):
                     multiple=False,
                 )
 
-                solara.InputInt(
+                IntegerInput(
                     label="Expected size",
                     value=expected_size,
                     on_value=set_expected_size,
+                    on_error_change=expected_size_error.set,
+                    continuous_update=True,
+                    outlined=True,
+                    hide_details="auto",
+                    classes=["pt-2"]
                 )
 
                 solara.Checkbox(
@@ -74,7 +82,8 @@ def CreateClassDialog(on_create_clicked: callable = None):
 
                 @solara.lab.computed
                 def create_button_disabled():
-                    return not (expected_size and text and stories)
+                    print(expected_size_error)
+                    return expected_size_error.value or (not (text and stories))
 
                 def _add_button_clicked(*args):
                     on_create_clicked(

--- a/src/cds_portal/pages/manage_classes/__init__.py
+++ b/src/cds_portal/pages/manage_classes/__init__.py
@@ -11,6 +11,7 @@ def CreateClassDialog(on_create_clicked: callable = None):
     active, set_active = solara.use_state(False)  #
     text, set_text = solara.use_state("")
     stories, set_stories = solara.use_state([])
+    expected_size, set_expected_size = solara.use_state(0)
 
     with rv.Dialog(
         v_model=active,
@@ -54,6 +55,12 @@ def CreateClassDialog(on_create_clicked: callable = None):
                     multiple=False,
                 )
 
+                solara.InputInt(
+                    label="Expected size",
+                    value=expected_size,
+                    on_value=set_expected_size,
+                )
+
             rv.Divider()
 
             with rv.CardActions():
@@ -63,6 +70,7 @@ def CreateClassDialog(on_create_clicked: callable = None):
                         {
                             "name": f"{text}",
                             "stories": f"{', '.join(stories)}",
+                            "expected_size": expected_size,
                         }
                     )
                     set_active(False)

--- a/src/cds_portal/pages/manage_classes/__init__.py
+++ b/src/cds_portal/pages/manage_classes/__init__.py
@@ -11,7 +11,7 @@ def CreateClassDialog(on_create_clicked: callable = None):
     active, set_active = solara.use_state(False)  #
     text, set_text = solara.use_state("")
     stories, set_stories = solara.use_state([])
-    expected_size, set_expected_size = solara.use_state(0)
+    expected_size, set_expected_size = solara.use_state(20)
 
     with rv.Dialog(
         v_model=active,
@@ -65,6 +65,10 @@ def CreateClassDialog(on_create_clicked: callable = None):
 
             with rv.CardActions():
 
+                @solara.lab.computed
+                def create_button_disabled():
+                    return not (expected_size and text and stories)
+
                 def _add_button_clicked(*args):
                     on_create_clicked(
                         {
@@ -79,7 +83,8 @@ def CreateClassDialog(on_create_clicked: callable = None):
 
                 solara.Button("Cancel", on_click=lambda: set_active(False), elevation=0)
                 solara.Button(
-                    "Create", color="info", on_click=_add_button_clicked, elevation=0
+                    "Create", color="info", on_click=_add_button_clicked, elevation=0,
+                    disabled=create_button_disabled.value
                 )
 
     return dialog
@@ -164,7 +169,7 @@ def Page():
     solara.use_effect(_retrieve_classes, [])
 
     def _create_class_callback(class_info):
-        BASE_API.create_new_class(class_info["name"])
+        BASE_API.create_new_class(class_info["name"], class_info["expected_size"])
         _retrieve_classes()
 
     def _delete_class_callback():

--- a/src/cds_portal/remote.py
+++ b/src/cds_portal/remote.py
@@ -127,7 +127,7 @@ class BaseAPI:
             json=payload,
         )
 
-        if r.status_code != 200:
+        if r.status_code != 201:
             logger.error("Failed to create new user.")
         else:
             logger.info(
@@ -160,7 +160,7 @@ class BaseAPI:
             json=form_data,
         )
 
-        if r.status_code != 200:
+        if r.status_code != 201:
             logger.error("Failed to create new user.")
 
             r = Response()

--- a/src/cds_portal/remote.py
+++ b/src/cds_portal/remote.py
@@ -123,7 +123,7 @@ class BaseAPI:
         }
 
         r = self.request_session.post(
-            f"{self.API_URL}/student-sign-up",
+            f"{self.API_URL}/students/create",
             json=payload,
         )
 
@@ -156,7 +156,7 @@ class BaseAPI:
         form_data.update({"username": self.hashed_user, "password": str(uuid.uuid4())})
 
         r = self.request_session.post(
-            f"{self.API_URL}/educator-sign-up",
+            f"{self.API_URL}/educators/create",
             json=form_data,
         )
 
@@ -179,7 +179,7 @@ class BaseAPI:
         educator = r.json()["educator"]
 
         r = self.request_session.post(
-            f"{self.API_URL}/create-class",
+            f"{self.API_URL}/classes/create",
             json={
                 "educator_id": educator["id"],
                 "name": name,

--- a/src/cds_portal/remote.py
+++ b/src/cds_portal/remote.py
@@ -174,13 +174,17 @@ class BaseAPI:
 
         return r
 
-    def create_new_class(self, name: str) -> dict:
+    def create_new_class(self, name: str, expected_size: int) -> dict:
         r = self.request_session.get(f"{self.API_URL}/educators/{self.hashed_user}")
         educator = r.json()["educator"]
 
         r = self.request_session.post(
             f"{self.API_URL}/create-class",
-            json={"educator_id": educator["id"], "name": name},
+            json={
+                "educator_id": educator["id"],
+                "name": name,
+                "expected_size": expected_size,
+            },
         )
 
         return r.json()

--- a/src/cds_portal/remote.py
+++ b/src/cds_portal/remote.py
@@ -174,7 +174,7 @@ class BaseAPI:
 
         return r
 
-    def create_new_class(self, name: str, expected_size: int) -> dict:
+    def create_new_class(self, info: dict) -> dict:
         r = self.request_session.get(f"{self.API_URL}/educators/{self.hashed_user}")
         educator = r.json()["educator"]
 
@@ -182,8 +182,9 @@ class BaseAPI:
             f"{self.API_URL}/classes/create",
             json={
                 "educator_id": educator["id"],
-                "name": name,
-                "expected_size": expected_size,
+                "name": info["name"],
+                "expected_size": info["expected_size"],
+                "asynchronous": info["asynchronous"],
             },
         )
 


### PR DESCRIPTION
This PR makes a few changes related to adding new students/educators/classes:
* Expect 201 response codes (rather than 200) for successful student & educator registration
* Update to use the newer `/create` endpoints (note that the old ones still work fine)
* Update class creation (in both the frontend and the backend) to account for the class expected size added in https://github.com/cosmicds/cds-api/pull/151

A couple notes:
* The expected size input field in the class creation dialog uses Solara's `InputInt` and thus the styling is somewhat different. I wasn't able to find a simple way to make the styling match the other two input widgets, but I'll come back to that in the future.
* The behavior of the `InputInt` is (IMO) a bit unintuitive. If the user enters something invalid, the associated value from the widget just stays as whatever it was before. So if I start with an expected class size of 20, then put in, say, "42.7", then the `expected_size` value is still 20, which will get passed to the database. Also, AFAICT, there's no way to access whether the widget input is in an error state, so I wasn't able to hook a check for that into the button-disable computed.