### PR TITLE
Return to root page after logout

### DIFF
--- a/src/cds_portal/layout.py
+++ b/src/cds_portal/layout.py
@@ -192,7 +192,7 @@ def Layout(children=[]):
                                 flat=True,
                                 text=False,
                                 on_click=lambda: router.push("/"),
-                                href=auth.get_logout_url(),
+                                href=auth.get_logout_url("/"),
                             )
 
         with rv.Content():


### PR DESCRIPTION
This PR provides a solution to avoid the logout issues that we were seeing in #12. The problem is that if I'm in a user-only page (e.g. the class management page) and logout, the OAuth currently attempts to return me to the current path, which will then error because the relevant user ID is not present. The solution here is to tell the OAuth to return us to the root path instead.

In the future, if we have more routes where only some are user-restricted, we could probably extend the logic here to only do this if the current route requires being logged in, but we aren't at that point yet.