### PR TITLE
Update launch link to HubbleDS

### DIFF
--- a/src/cds_portal/pages/student_classes/__init__.py
+++ b/src/cds_portal/pages/student_classes/__init__.py
@@ -136,7 +136,7 @@ def Page():
                                 # outlined=True,
                                 depressed=True,
                                 color="success",
-                                href="https://app.cosmicds.cfa.harvard.edu",
+                                href="http://cds-hub-law-demo.eba-5uqxv4pp.us-east-1.elasticbeanstalk.com/",
                                 target="_blank",
                             ),
                             # rv.Btn(


### PR DESCRIPTION
Updates the launch button in the student management area to point to the demo notebook.