### PR TITLE
Allow setting Hubble waiting room override for a class

### DIFF
--- a/src/cds_portal/pages/manage_classes/__init__.py
+++ b/src/cds_portal/pages/manage_classes/__init__.py
@@ -235,12 +235,17 @@ def ClassActionsDialog(disabled: bool, class_data: list[dict]):
 
                 with rv.Container():
                     with rv.CardText():
-                        solara.Text("Set the small class override for the selected classes. If a class already has the override set, there will be no effect. "
-                                    "If the button is disabled, all of your classes are either small classes or have the override set already.")
+                        solara.Text("Set the small class override for the selected classes. If a class already has the override set, there will be no effect.")
                     with solara.Row():
-                        solara.Button(label="Set override",
+                        no_override_count = len(hubble_classes) - sum(override_statuses)
+                        no_override_classes = "class" if no_override_count == 1 else "classes"
+                        solara.Button(label=f"Set override",
                                       on_click=_on_override_button_pressed,
                                       disabled=all_overridden)
+                        rv.Alert(children=[f"This will affect {no_override_count} {no_override_classes}"],
+                                 color="info",
+                                 outlined=True,
+                                 dense=True)
 
                 rv.Spacer()
 

--- a/src/cds_portal/pages/manage_classes/__init__.py
+++ b/src/cds_portal/pages/manage_classes/__init__.py
@@ -223,7 +223,7 @@ def ClassActionsDialog(disabled: bool, class_data: list[dict]):
                                     _update_snackbar(message=message, color=color)
 
                                 solara.Checkbox(label="Set small class override",
-                                                disabled=data["small_class"],
+                                                disabled=override_status or data["small_class"],
                                                 value=override_status,
                                                 on_value=_on_checkbox_changed)
 
@@ -249,7 +249,7 @@ def Page():
         new_classes = [
             {
                 "name": cls["name"],
-                "date": datetime.fromisoformat(cls["created"]).strftime("%m/%d/%Y"),
+                "date": datetime.fromisoformat(cls["created"].removesuffix("Z")).strftime("%m/%d/%Y"),
                 "story": "Hubble's Law",
                 "code": cls["code"],
                 "id": cls["id"],

--- a/src/cds_portal/pages/manage_students/__init__.py
+++ b/src/cds_portal/pages/manage_students/__init__.py
@@ -80,10 +80,10 @@ def Page():
                         "class_id": cls["id"],
                         "username": student["username"],
                         "created": datetime.fromisoformat(
-                            student["profile_created"]
+                            student["profile_created"].removesuffix("Z")
                         ).strftime("%m/%d/%Y"),
                         "last_visit": datetime.fromisoformat(
-                            student["last_visit"]
+                            student["last_visit"].removesuffix("Z")
                         ).strftime("%m/%d/%Y"),
                         "class": cls["name"],
                         "story": "Hubble's Law",

--- a/src/cds_portal/pages/student_classes/__init__.py
+++ b/src/cds_portal/pages/student_classes/__init__.py
@@ -80,6 +80,7 @@ def Page():
     selected_rows, set_selected_rows = solara.use_state([])
 
     def _retrieve_classes():
+        print(BASE_API.load_student_info())
         classes_response = BASE_API.load_student_classes()
         formatted_classes = []
 
@@ -90,7 +91,7 @@ def Page():
                 "name": cls["name"],
                 "code": cls["code"],
                 "educator": f"{educator_response['first_name']} {educator_response['last_name']}",
-                "date": datetime.fromisoformat(cls["created"]).strftime("%m/%d/%Y"),
+                "date": datetime.fromisoformat(cls["created"].removesuffix("Z")).strftime("%m/%d/%Y"),
             }
 
             formatted_classes.append(cls_fmt)

--- a/src/cds_portal/remote.py
+++ b/src/cds_portal/remote.py
@@ -224,6 +224,23 @@ class BaseAPI:
 
         return r
 
+    def get_hubble_waiting_room_override(self, class_id: int) -> dict:
+        r = self.request_session.get(
+            f"{self.API_URL}/hubbles_law/waiting-room-override/{class_id}"
+        )
+
+        return r.json()
+
+    def set_hubble_waiting_room_override(self, class_id: int, value: bool) -> Response:
+        method = self.request_session.put if value else self.request_session.delete
+        r = method(
+            f"{self.API_URL}/hubbles_law/waiting-room-override",
+            data={"class_id": class_id}, 
+        )
+
+        return r
+
+
     @staticmethod
     def clear_user(state: Reactive[GlobalState]):
         Ref(state.fields.student.id).set(0)

--- a/src/cds_portal/remote.py
+++ b/src/cds_portal/remote.py
@@ -235,7 +235,7 @@ class BaseAPI:
         method = self.request_session.put if value else self.request_session.delete
         r = method(
             f"{self.API_URL}/hubbles_law/waiting-room-override",
-            data={"class_id": class_id}, 
+            json={"class_id": class_id},
         )
 
         return r


### PR DESCRIPTION
This PR updates the class management page on the portal to allow an educator to set whether or not they want their class to have the waiting room override (i.e. to treat it as a small class even if it's not). This is done using the classes data table that already existed.

The one wrinkle with this is that AFAICT there's no way to get the data for the particular row in a v-slot using ipyvuetify. So to get around this, I've added another button ("Modify Class") to the top of the data table. That button opens a dialog that allows doing whatever sort of modification is relevant for each selected class - currently that's just setting the override in the Hubble story, but in the future this can have more options. Since we allow selecting multiple classes (which is useful for things like deleting classes), the dialog creates a separate tab for each selected class.