### PR TITLE
Check for educator class access

### DIFF
--- a/src/cds_portal/components/educator_dashboard/educator_dashboard.py
+++ b/src/cds_portal/components/educator_dashboard/educator_dashboard.py
@@ -18,10 +18,7 @@ from solara.lab import theme, ThemeToggle
 
 
 @solara.component
-def EducatorDashboard():
-    router = solara.use_router()
-    url_params = {x.split("=")[0]: x.split("=")[1] for x in router.search.split("&")}
-
+def EducatorDashboard(url_params):
     query = QueryCosmicDSApi()
     show_dashboard, set_show_dashboard = solara.use_state(False)
     class_id_list = solara.use_reactive([int(url_params["id"])])

--- a/src/cds_portal/pages/educator-dashboard/__init__.py
+++ b/src/cds_portal/pages/educator-dashboard/__init__.py
@@ -1,12 +1,23 @@
 import solara
+from ...remote import BASE_API
 from solara.alias import rv
-from cds_portal.components.educator_dashboard import EducatorDashboard
+from ...components.educator_dashboard import EducatorDashboard
 
 
 @solara.component
 def Page():
+    router = solara.use_router()
+    url_params = {x.split("=")[0]: x.split("=")[1] for x in router.search.split("&")}
+
+    classes_dict = BASE_API.load_educator_classes()
+    educator_class_ids = [str(cls["id"]) for cls in classes_dict["classes"]]
+
     with solara.Row(classes=["fill-height"]):
         with rv.Col(cols=12):
             solara.Div("Educator Dashboard", classes=["display-1", "mb-8"])
 
-            EducatorDashboard()
+            if url_params.get("id") not in educator_class_ids:
+                solara.Markdown("You do not have access to this class.")
+                return
+            else:
+                EducatorDashboard(url_params)


### PR DESCRIPTION
This addresses #27 by checking to see if the class id in the URL parameters is in the list of class ids that educator belongs to. If not, we display a message stating they do not have access to the class dashboard.