### PR TITLE
Configuration updates, part 2

### DIFF
--- a/src/cds_portal/layout.py
+++ b/src/cds_portal/layout.py
@@ -118,6 +118,7 @@ def Layout(children=[]):
                         ],
                     ):
                         with rv.List(dense=True, nav=True, max_width=300):
+                            user_type, user_id = BASE_API.user_type_id
                             with rv.ListItem():
                                 rv.ListItemAvatar(
                                     children=[
@@ -141,6 +142,11 @@ def Layout(children=[]):
                                                 f"{auth.user.value['userinfo'].get('cds/email', '')}"
                                             ]
                                         ),
+                                        rv.ListItemSubtitle(
+                                            children=[
+                                                f"{user_type} ID: {user_id}"
+                                            ]
+                                        )
                                     ]
                                 )
 

--- a/src/cds_portal/pages/manage_classes/__init__.py
+++ b/src/cds_portal/pages/manage_classes/__init__.py
@@ -349,7 +349,7 @@ def Page():
                         {"text": "Date", "value": "date"},
                         {"text": "Story", "value": "story"},
                         {"text": "Code", "value": "code"},
-                        {"text": "ID", "value": "id", "align": " d-none"},
+                        {"text": "ID", "value": "id", "align": "d-none"},
                         {"text": "Expected size", "value": "expected_size"},
                         {"text": "Asynchronous", "value": "asynchronous"},
                     ]

--- a/src/cds_portal/pages/manage_classes/__init__.py
+++ b/src/cds_portal/pages/manage_classes/__init__.py
@@ -219,6 +219,24 @@ def ClassActionsDialog(disabled: bool, class_data: list[dict]):
             with rv.CardText():
                 solara.Div("From this dialog you can make any necessary changes to the selected classes")
 
+            def _on_active_switched(active: bool):
+                for data in class_data:
+                    BASE_API.set_class_active(data["id"], "hubbles_law", active)
+
+            with rv.Container():
+                with rv.CardText():
+                    single_class = len(class_data) == 1
+                    classes_string = "class" if single_class else "classes"
+                    is_are_string = "is" if single_class else "are"
+                    solara.Text(f"Set whether or not the selected {classes_string} {is_are_string} active")
+                with solara.Row():
+                    any_active = any(BASE_API.get_class_active(data["id"], "hubbles_law") for data in class_data)
+                    solara.Switch(label="Set active", value=any_active, on_value=_on_active_switched)
+                    rv.Alert(children=[f"This will affect {len(class_data)} {classes_string}"],
+                             color="info",
+                             outlined=True,
+                             dense=True)
+
             if "Hubble's Law" in classes_by_story:
 
                 hubble_classes = classes_by_story["Hubble's Law"]
@@ -250,7 +268,7 @@ def ClassActionsDialog(disabled: bool, class_data: list[dict]):
                     with solara.Row():
                         no_override_count = len(hubble_classes) - sum(override_statuses)
                         no_override_classes = "class" if no_override_count == 1 else "classes"
-                        solara.Button(label=f"Set override",
+                        solara.Button(label="Set override",
                                       on_click=_on_override_button_pressed,
                                       disabled=all_overridden)
                         rv.Alert(children=[f"This will affect {no_override_count} {no_override_classes}"],

--- a/src/cds_portal/pages/manage_classes/__init__.py
+++ b/src/cds_portal/pages/manage_classes/__init__.py
@@ -279,7 +279,7 @@ def ClassActionsDialog(disabled: bool, class_data: list[dict]):
                 rv.Spacer()
 
                 with rv.CardActions():
-                    solara.Button("Cancel", on_click=close_dialog, elevation=0)
+                    solara.Button("Close", on_click=close_dialog, elevation=0)
 
         rv.Snackbar(v_model=bool(message),
                     on_v_model=lambda *args: _reset_snackbar(),

--- a/src/cds_portal/pages/student_classes/__init__.py
+++ b/src/cds_portal/pages/student_classes/__init__.py
@@ -81,7 +81,6 @@ def Page():
     selected_rows, set_selected_rows = solara.use_state(None)
 
     def _retrieve_classes():
-        print(BASE_API.load_student_info())
         classes_response = BASE_API.load_student_classes()
         formatted_classes = []
 
@@ -129,6 +128,7 @@ def Page():
                     show_select=False,
                     v_model=selected_rows,
                     on_v_model=set_selected_rows,
+                    item_key="code",
                     headers=[
                         {"text": "Date", "value": "date", "sortable": True},
                         {

--- a/src/cds_portal/pages/student_classes/__init__.py
+++ b/src/cds_portal/pages/student_classes/__init__.py
@@ -111,21 +111,28 @@ def Page():
                 with rv.Toolbar(flat=True, dense=True, class_="pa-0"):
                     rv.Spacer()
                     with rv.ToolbarItems():
-                        code = selected_rows[0]["code"] if selected_rows else None
+                        class_selected = bool(selected_rows)
+                        if class_selected:
+                            class_data = selected_rows[0]
+                            code = class_data["code"]
+                            active = BASE_API.get_class_active(class_data["code"], "hubbles_law")
+                        else:
+                            code = None
+                            active = False
                         query_string = f"?class_code={code}" if code else ""
                         solara.Button(
                             "Launch",
                             text=False,
                             color="success",
-                            disabled=not bool(selected_rows),
+                            disabled=not (class_selected and active),
                             href=f"{settings.main.base_url}hubbles-law{query_string}",
                             target="_blank"
                         )
 
                 rv.DataTable(
                     items=classes.value,
-                    single_select=False,
-                    show_select=False,
+                    single_select=True,
+                    show_select=True,
                     v_model=selected_rows,
                     on_v_model=set_selected_rows,
                     item_key="code",

--- a/src/cds_portal/pages/student_classes/__init__.py
+++ b/src/cds_portal/pages/student_classes/__init__.py
@@ -78,7 +78,7 @@ def JoinClassDialog(callback: callable = lambda: None):
 @solara.component
 def Page():
     classes = solara.use_reactive([])
-    selected_rows, set_selected_rows = solara.use_state([])
+    selected_rows, set_selected_rows = solara.use_state(None)
 
     def _retrieve_classes():
         print(BASE_API.load_student_info())
@@ -108,55 +108,55 @@ def Page():
                 rv.Spacer()
                 JoinClassDialog(callback=_retrieve_classes)
 
-            rv.DataTable(
-                items=classes.value,
-                single_select=False,
-                show_select=False,
-                v_model=selected_rows,
-                on_v_model=set_selected_rows,
-                headers=[
-                    {"text": "Date", "value": "date", "sortable": True},
-                    {
-                        "text": "Name",
-                        "align": "start",
-                        "sortable": True,
-                        "value": "name",
-                    },
-                    {"text": "Educator", "value": "educator"},
-                    {"text": "Code", "value": "code"},
-                    {"text": "", "value": "actions", "align": "end"},
-                ],
-                v_slots=[
-                    {
-                        "name": "item.actions",
-                        "variable": "y",
-                        "children": [
-                            solara.Button(
-                                "Pre-survey",
-                                text=False,
-                                icon_name="mdi-folder-account-outline",
-                                depressed=True,
-                                color="info",
-                                href="",
-                                target="_blank",
-                                style={"margin": "0 5px"},
-                            ),
-                            solara.Button(
-                                "Launch",
-                                text=False,
-                                icon_name="mdi-pencil",
-                                # outlined=True,
-                                depressed=True,
-                                color="success",
-                                href=f"{settings.main.base_url}hubbles-law",
-                                target="_blank",
-                            ),
-                            # rv.Btn(
-                            #     icon=True,
-                            #     # on_click=lambda: print("Delete"),
-                            #     children=[rv.Icon(children=["mdi-delete"])],
-                            # ),
-                        ],
-                    },
-                ],
-            )
+            with rv.Card(outlined=True, flat=True):
+                with rv.Toolbar(flat=True, dense=True, class_="pa-0"):
+                    rv.Spacer()
+                    with rv.ToolbarItems():
+                        code = selected_rows[0]["code"] if selected_rows else None
+                        query_string = f"?class_code={code}" if code else ""
+                        solara.Button(
+                            "Launch",
+                            text=False,
+                            color="success",
+                            disabled=not bool(selected_rows),
+                            href=f"{settings.main.base_url}hubbles-law{query_string}",
+                            target="_blank"
+                        )
+
+                rv.DataTable(
+                    items=classes.value,
+                    single_select=False,
+                    show_select=False,
+                    v_model=selected_rows,
+                    on_v_model=set_selected_rows,
+                    headers=[
+                        {"text": "Date", "value": "date", "sortable": True},
+                        {
+                            "text": "Name",
+                            "align": "start",
+                            "sortable": True,
+                            "value": "name",
+                        },
+                        {"text": "Educator", "value": "educator"},
+                        {"text": "Code", "value": "code"},
+                        {"text": "", "value": "actions", "align": "end"},
+                    ],
+                    v_slots=[
+                        {
+                            "name": "item.actions",
+                            "variable": "y",
+                            "children": [
+                                solara.Button(
+                                    "Pre-survey",
+                                    text=False,
+                                    icon_name="mdi-folder-account-outline",
+                                    depressed=True,
+                                    color="info",
+                                    href="",
+                                    target="_blank",
+                                    style={"margin": "0 5px"},
+                                ),
+                            ],
+                        },
+                    ],
+                )

--- a/src/cds_portal/pages/student_classes/__init__.py
+++ b/src/cds_portal/pages/student_classes/__init__.py
@@ -132,6 +132,16 @@ def Page():
                         "variable": "y",
                         "children": [
                             solara.Button(
+                                "Pre-survey",
+                                text=False,
+                                icon_name="mdi-folder-account-outline",
+                                depressed=True,
+                                color="info",
+                                href="",
+                                target="_blank",
+                                style={"margin": "0 5px"},
+                            ),
+                            solara.Button(
                                 "Launch",
                                 text=False,
                                 icon_name="mdi-pencil",

--- a/src/cds_portal/pages/student_classes/__init__.py
+++ b/src/cds_portal/pages/student_classes/__init__.py
@@ -104,13 +104,11 @@ def Page():
         with rv.Col(cols=12):
             with rv.Row(class_="pa-0 mb-8 mx-0"):
                 solara.Text("Class Overview", classes=["display-1"])
-                rv.Spacer()
-                JoinClassDialog(callback=_retrieve_classes)
 
             with rv.Card(outlined=True, flat=True):
                 with rv.Toolbar(flat=True, dense=True, class_="pa-0"):
-                    rv.Spacer()
                     with rv.ToolbarItems():
+                        JoinClassDialog(callback=_retrieve_classes)
                         class_selected = bool(selected_rows)
                         if class_selected:
                             class_data = selected_rows[0]

--- a/src/cds_portal/remote.py
+++ b/src/cds_portal/remote.py
@@ -59,6 +59,14 @@ class BaseAPI:
         r = self.request_session.get(f"{self.API_URL}/educators/{self.hashed_user}")
         return r.json()["educator"] is not None
 
+    @property
+    def user_type_id(self) -> tuple[str | None, int | None]:
+        if self.educator_exists:
+            return "Educator", self.load_educator_info()["id"]
+        elif self.student_exists:
+            return "Student", self.load_student_info()["id"]
+        return None, None
+
     def validate_class_code(self, class_code: str) -> bool:
         r = self.request_session.get(
             f"{self.API_URL}/validate-classroom-code/{class_code}"

--- a/src/cds_portal/remote.py
+++ b/src/cds_portal/remote.py
@@ -50,20 +50,20 @@ class BaseAPI:
         return hashed
 
     @property
-    def student_exists(self):
+    def student_info(self):
         r = self.request_session.get(f"{self.API_URL}/students/{self.hashed_user}")
-        return r.json()["student"] is not None
+        return r.json()["student"]
 
     @property
-    def educator_exists(self):
+    def educator_info(self):
         r = self.request_session.get(f"{self.API_URL}/educators/{self.hashed_user}")
-        return r.json()["educator"] is not None
+        return r.json()["educator"]
 
     @property
     def user_type_id(self) -> tuple[str | None, int | None]:
-        if self.educator_exists:
+        if self.educator_info:
             return "Educator", self.load_educator_info()["id"]
-        elif self.student_exists:
+        elif self.student_info:
             return "Student", self.load_student_info()["id"]
         return None, None
 
@@ -248,6 +248,19 @@ class BaseAPI:
         )
 
         return r
+
+    def get_class_active(self, class_id: int, story_name: str) -> bool:
+        r = self.request_session.get(
+            f"{self.API_URL}/classes/active/{class_id}/{story_name}",
+        )
+        return r.json()["active"]
+
+    def set_class_active(self, class_id: int, story_name: str, active: bool) -> bool:
+        r = self.request_session.post(
+            f"{self.API_URL}/classes/active/{class_id}/{story_name}",
+            json={"active", active},
+        )
+        return r.json()["success"]
 
 
     @staticmethod

--- a/src/cds_portal/remote.py
+++ b/src/cds_portal/remote.py
@@ -258,7 +258,7 @@ class BaseAPI:
     def set_class_active(self, class_id: int, story_name: str, active: bool) -> bool:
         r = self.request_session.post(
             f"{self.API_URL}/classes/active/{class_id}/{story_name}",
-            json={"active", active},
+            json={"active": active},
         )
         return r.json()["success"]
 

--- a/src/cds_portal/remote.py
+++ b/src/cds_portal/remote.py
@@ -52,12 +52,12 @@ class BaseAPI:
     @property
     def student_info(self):
         r = self.request_session.get(f"{self.API_URL}/students/{self.hashed_user}")
-        return r.json()["student"]
+        return r.json().get("student", None)
 
     @property
     def educator_info(self):
         r = self.request_session.get(f"{self.API_URL}/educators/{self.hashed_user}")
-        return r.json()["educator"]
+        return r.json().get("educator", None)
 
     @property
     def user_type_id(self) -> tuple[str | None, int | None]:


### PR DESCRIPTION
This PR does the following:
* Allows setting whether or not a class is active from the class actions dialog
* Reconfigure student classes page to only be able to allow selecting one class at a time. This allows us to solve the portal-side piece of https://github.com/cosmicds/hubbleds/issues/901 (this doesn't do anything yet as it also requires app-side changes as well)
* Don't allow student to launch the selected story if that class+story combo isn't marked as active in the database

Note that this is built on top of #36.